### PR TITLE
Unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.133 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,6 @@ version = "0.0.1"
 dependencies = [
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.133 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 [dependencies]
 clippy = { version = "0.0", optional = true }
 bufstream = "*"
-lazy_static = "*"
 log = "*"
 nom = "*"
 num = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 clippy = { version = "0.0", optional = true }
+bufstream = "*"
+lazy_static = "*"
 log = "*"
 nom = "*"
 num = "*"
@@ -22,7 +24,6 @@ serde_derive = "*"
 serde_json = "*"
 time = "*"
 toml = "*"
-bufstream = "*"
 walkdir = "*"
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     Json(JsonError),
     /// An error which occurs when attempting to read the UID for a message.
     MessageUidDecode,
+    /// An error which occurs when a Maildir message has a bad filename
+    MessageBadFilename,
     /// An internal `mime` error.
     Mime(mime::Error),
     /// An internal `toml` error which occurs when serializing or deserializing
@@ -32,7 +34,7 @@ impl fmt::Display for Error {
         use self::Error::*;
 
         match *self {
-            InvalidImapState | MessageUidDecode => write!(f, "{}", StdError::description(self)),
+            InvalidImapState | MessageUidDecode | MessageBadFilename => write!(f, "{}", StdError::description(self)),
             Io(ref e) => e.fmt(f),
             Json(ref e) => e.fmt(f),
             Mime(ref e) => e.fmt(f),
@@ -48,6 +50,7 @@ impl StdError for Error {
         match *self {
             InvalidImapState => "Not in selected state.",
             MessageUidDecode => "An error occured while decoding the UID for a message.",
+            MessageBadFilename => "An error occured while parsing message information from its filename",
             Io(ref e) => e.description(),
             Json(ref e) => e.description(),
             Mime(ref e) => e.description(),
@@ -59,7 +62,7 @@ impl StdError for Error {
         use self::Error::*;
 
         match *self {
-            InvalidImapState | MessageUidDecode => None,
+            InvalidImapState | MessageUidDecode | MessageBadFilename => None,
             Io(ref e) => e.cause(),
             Json(ref e) => e.cause(),
             Mime(ref e) => e.cause(),

--- a/src/folder.rs
+++ b/src/folder.rs
@@ -238,18 +238,19 @@ impl Folder {
             }
 
             // Create the FETCH response for this STORE operation.
-            let message = &mut self.messages.get_mut(i-1).unwrap();
-            responses.push_str("* ");
-            responses.push_str(&i.to_string()[..]);
-            responses.push_str(" FETCH (FLAGS ");
-            responses.push_str(&message.store(flag_name, flags.clone())[..]);
+            if let Some(mut message) = self.messages.get_mut(i-1) {
+                responses.push_str("* ");
+                responses.push_str(&i.to_string()[..]);
+                responses.push_str(" FETCH (FLAGS ");
+                responses.push_str(&message.store(flag_name, flags.clone())[..]);
 
-            // UID STORE needs to respond with the UID for each FETCH response
-            if seq_uid {
-                let uid_res = format!(" UID {}", uid);
-                responses.push_str(&uid_res[..]);
+                // UID STORE needs to respond with the UID for each FETCH response
+                if seq_uid {
+                    let uid_res = format!(" UID {}", uid);
+                    responses.push_str(&uid_res[..]);
+                }
+                responses.push_str(" )\r\n");
             }
-            responses.push_str(" )\r\n");
         }
 
         // Return an empty string if the client wanted the STORE to be SILENT

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,12 +34,15 @@ use bufstream::BufStream;
 mod command;
 mod error;
 mod folder;
-mod message;
 mod mime;
 mod parser;
+#[macro_use]
 mod server;
-mod user;
+#[macro_use]
 mod util;
+
+mod user;
+mod message;
 
 fn main() {
     // Create the server. We wrap it so that it is atomically reference

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,14 @@ mod util;
 fn main() {
     // Create the server. We wrap it so that it is atomically reference
     // counted. This allows us to safely share it across threads
-    let serv = Arc::new(Server::new().unwrap());
+
+    let serv = match Server::new() {
+        Err(e) => {
+            error!("Error starting server: {}", e);
+            return;
+        },
+        Ok(s) => Arc::new(s)
+    };
 
     // Spawn a separate thread for listening for LMTP connections
     match serv.lmtp_listener() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@
 extern crate bufstream;
 extern crate crypto;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate nom;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@
 
 extern crate bufstream;
 extern crate crypto;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
 #[macro_use]
 extern crate nom;
 extern crate num;

--- a/src/message.rs
+++ b/src/message.rs
@@ -77,7 +77,7 @@ impl Message {
         let mime_message = MIME_Message::new(arg_path)?;
 
         // Grab the string in the filename representing the flags
-        let mut path = arg_path.file_name().unwrap().to_str().unwrap().splitn(1, ':');
+        let mut path = path_filename_to_str!(arg_path).splitn(1, ':');
         let filename = match path.next() {
             Some(fname) => fname,
             None => { return Err(Error::MessageBadFilename); }

--- a/src/message.rs
+++ b/src/message.rs
@@ -78,7 +78,10 @@ impl Message {
 
         // Grab the string in the filename representing the flags
         let mut path = arg_path.file_name().unwrap().to_str().unwrap().splitn(1, ':');
-        let filename = path.next().unwrap();
+        let filename = match path.next() {
+            Some(fname) => fname,
+            None => { return Err(Error::MessageBadFilename); }
+        };
         let path_flags = path.next();
 
         // Retrieve the UID from the provided filename.

--- a/src/message.rs
+++ b/src/message.rs
@@ -88,26 +88,29 @@ impl Message {
         let flags = match path_flags {
             // if there are no flags, create an empty set
             None => HashSet::new(),
-            Some(flags) => {
+            Some(flags) =>
                 // The uid is separated from the flag part of the filename by a
                 // colon. The flag part consists of a 2 followed by a comma and
                 // then some letters. Those letters represent the message flags
-                let unparsed_flags = flags.splitn(1, ',').nth(1).unwrap();
-                let mut set_flags: HashSet<Flag> = HashSet::new();
-                for flag in unparsed_flags.chars() {
-                    let parsed_flag = match flag {
-                        'D' => Some(Flag::Draft),
-                        'F' => Some(Flag::Flagged),
-                        'R' => Some(Flag::Answered),
-                        'S' => Some(Flag::Seen),
-                        _ => None
-                    };
-                    if let Some(enum_flag) = parsed_flag {
-                        set_flags.insert(enum_flag);
+                match flags.splitn(1, ',').nth(1) {
+                    None => HashSet::new(),
+                    Some(unparsed_flags) => {
+                        let mut set_flags: HashSet<Flag> = HashSet::new();
+                        for flag in unparsed_flags.chars() {
+                            let parsed_flag = match flag {
+                                'D' => Some(Flag::Draft),
+                                'F' => Some(Flag::Flagged),
+                                'R' => Some(Flag::Answered),
+                                'S' => Some(Flag::Seen),
+                                _ => None
+                            };
+                            if let Some(enum_flag) = parsed_flag {
+                                set_flags.insert(enum_flag);
+                            }
+                        }
+                        set_flags
                     }
                 }
-                set_flags
-            }
         };
 
         let message = Message {

--- a/src/server/lmtp.rs
+++ b/src/server/lmtp.rs
@@ -14,6 +14,9 @@ use server::Server;
 use user::Email;
 use user::User;
 
+// Just bail if there is some error.
+// Used when performing operations on a TCP Stream generally
+#[macro_export]
 macro_rules! return_on_err(
     ($inp:expr) => {
         if $inp.is_err() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,7 +11,8 @@ use self::config::Config;
 use user::{load_users, Email, User};
 
 mod config;
-mod lmtp;
+#[macro_use]
+pub mod lmtp;
 
 /// Holds configuration state and email->user map
 pub struct Server {

--- a/src/user/session.rs
+++ b/src/user/session.rs
@@ -24,16 +24,6 @@ use error::Error;
 use super::login::LoginData;
 use util;
 
-// Just bail if there is some error.
-// Used when performing operations on a TCP Stream generally
-macro_rules! return_on_err(
-    ($inp:expr) => {
-        if $inp.is_err() {
-            return;
-        }
-    }
-);
-
 // Used to grab every file for removal while performing DELETE on a folder.
 macro_rules! opendirlisting(
     ($inp:expr, $listing:ident, $err:ident, $next:expr) => {
@@ -351,10 +341,9 @@ impl Session {
                             let re_opt = Regex::new
                                           (&format!
                                            ("{}/?{}/?{}$",
-                                            maildir_path.file_name().unwrap().to_str()
-                                            .unwrap(), reference,
-                                            mailbox_name.replace
-                                            ("INBOX", ""))[..]);
+                                            path_filename_to_str!(maildir_path),
+                                            reference,
+                                            mailbox_name.replace("INBOX", ""))[..]);
                             match re_opt {
                                 Err(_) => { return bad_res;}
                                 Ok(re) => {

--- a/src/user/session.rs
+++ b/src/user/session.rs
@@ -234,7 +234,7 @@ impl Session {
                 "create" => {
                     let create_args: Vec<&str> = args.collect();
                     if create_args.len() < 1 { return bad_res; }
-                    let mbox_name = util::inbox_re().replace
+                    let mbox_name = util::INBOX_RE.replace
                                      (create_args[0].trim_matches('"'), "");
                     match self.maildir {
                         None => return bad_res,
@@ -273,7 +273,7 @@ impl Session {
                 "delete" => {
                     let delete_args: Vec<&str> = args.collect();
                     if delete_args.len() < 1 { return bad_res; }
-                    let mbox_name = util::inbox_re().replace
+                    let mbox_name = util::INBOX_RE.replace
                                      (delete_args[0].trim_matches('"'), "");
                     match self.maildir {
                         None => return bad_res,

--- a/src/user/session.rs
+++ b/src/user/session.rs
@@ -122,9 +122,13 @@ impl Session {
         // The client will need the tag in the response in order to match up
         // the response to the command it issued because the client does not
         // have to wait on our response in order to issue new commands.
-        let tag = args.next().unwrap();
+        let inv_str = " BAD Invalid command\r\n";
+        let tag = match args.next() {
+            None => return inv_str.to_string(),
+            Some(t) => t
+        };
         let mut bad_res = tag.to_string();
-        bad_res.push_str(" BAD Invalid command\r\n");
+        bad_res.push_str(inv_str);
 
         // The argument after the tag specified the command issued.
         // Additional arguments are arguments for that specific command.

--- a/src/user/session.rs
+++ b/src/user/session.rs
@@ -224,15 +224,13 @@ impl Session {
                 "create" => {
                     let create_args: Vec<&str> = args.collect();
                     if create_args.len() < 1 { return bad_res; }
-                    let mbox_name = util::INBOX_RE.replace
-                                     (create_args[0].trim_matches('"'), "");
+                    let mbox_name = create_args[0].trim_matches('"').replace("INBOX", "");
                     match self.maildir {
                         None => return bad_res,
                         Some(ref maildir) => {
                             let mut no_res = tag.to_string();
                             no_res.push_str(" NO Could not create folder.\r\n");
-                            let maildir_path = Path::new(&maildir[..])
-                                                .join(mbox_name.as_ref());
+                            let maildir_path = Path::new(&maildir[..]).join(mbox_name);
 
                             // Create directory for new mail
                             let newmaildir_path = maildir_path.join("new");
@@ -263,15 +261,13 @@ impl Session {
                 "delete" => {
                     let delete_args: Vec<&str> = args.collect();
                     if delete_args.len() < 1 { return bad_res; }
-                    let mbox_name = util::INBOX_RE.replace
-                                     (delete_args[0].trim_matches('"'), "");
+                    let mbox_name = delete_args[0].trim_matches('"').replace("INBOX", "");
                     match self.maildir {
                         None => return bad_res,
                         Some(ref maildir) => {
                             let mut no_res = tag.to_string();
                             no_res.push_str(" NO Invalid folder.\r\n");
-                            let maildir_path = Path::new(&maildir[..])
-                                                .join(mbox_name.as_ref());
+                            let maildir_path = Path::new(&maildir[..]).join(mbox_name);
                             let newmaildir_path = maildir_path.join("new");
                             let curmaildir_path = maildir_path.join("cur");
                             opendirlisting!(&newmaildir_path, newlist,

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,10 @@ use walkdir::WalkDir;
 
 use folder::Folder;
 
+lazy_static! {
+    pub static ref INBOX_RE : Regex = Regex::new("INBOX").unwrap();
+}
+
 fn make_absolute(dir: &Path) -> String {
     match current_dir() {
         Err(_) => dir.display().to_string(),
@@ -23,13 +27,11 @@ fn make_absolute(dir: &Path) -> String {
     }
 }
 
-pub fn inbox_re() -> Regex { Regex::new("INBOX").unwrap() }
-
 pub fn perform_select(maildir: &str, select_args: &[&str], examine: bool,
                       tag: &str) -> (Option<Folder>, String) {
     let err_res = (None, "".to_string());
     if select_args.len() < 1 { return err_res; }
-    let mbox_name = inbox_re().replace(select_args[0].trim_matches('"'), "."); // "));
+    let mbox_name = INBOX_RE.replace(select_args[0].trim_matches('"'), ".");
     let mut maildir_path = PathBuf::new();
     maildir_path.push(maildir);
     maildir_path.push(mbox_name.as_ref());
@@ -134,7 +136,7 @@ fn list_dir(dir: &Path, regex: &Regex, maildir_path: &Path) -> Option<String> {
             let mut list_str = "* LIST (".to_string();
             list_str.push_str(&flags[..]);
             list_str.push_str(") \"/\" ");
-            list_str.push_str(&(inbox_re().replace
+            list_str.push_str(&(INBOX_RE.replace
                               (&re.replace(&abs_dir[..], "INBOX")[..],
                                ""))[..]);
             Some(list_str)

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,16 +14,10 @@ use folder::Folder;
 
 #[macro_export]
 macro_rules! path_filename_to_str(
-    ($p:ident) => (
-        match $p.file_name() {
-            Some(filename) =>
-                match filename.to_str() {
-                    Some(fns) => fns,
-                    None => "",
-                },
-            None => ""
-        }
-    );
+    ($p:ident) => ({
+        use std::ffi::OsStr;
+        $p.file_name().unwrap_or_else(|| OsStr::new("")).to_str().unwrap_or_else(|| "")
+    });
 );
 
 fn make_absolute(dir: &Path) -> String {
@@ -32,7 +26,7 @@ fn make_absolute(dir: &Path) -> String {
         Ok(absp) => {
             let mut abs_path = absp.clone();
             abs_path.push(dir);
-            abs_path.as_path().display().to_string()
+            abs_path.display().to_string()
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,20 @@ lazy_static! {
     pub static ref INBOX_RE : Regex = Regex::new("INBOX").unwrap();
 }
 
+#[macro_export]
+macro_rules! path_filename_to_str(
+    ($p:ident) => (
+        match $p.file_name() {
+            Some(filename) =>
+                match filename.to_str() {
+                    Some(fns) => fns,
+                    None => "",
+                },
+            None => ""
+        }
+    );
+);
+
 fn make_absolute(dir: &Path) -> String {
     match current_dir() {
         Err(_) => dir.display().to_string(),
@@ -48,7 +62,7 @@ pub fn perform_select(maildir: &str, select_args: &[&str], examine: bool,
 /// generate the LIST response for it.
 fn list_dir(dir: &Path, regex: &Regex, maildir_path: &Path) -> Option<String> {
     let dir_string = dir.display().to_string();
-    let dir_name = dir.file_name().unwrap().to_str().unwrap();
+    let dir_name = path_filename_to_str!(dir);
 
     // These folder names are used to hold mail. Every other folder is
     // valid.
@@ -94,7 +108,7 @@ fn list_dir(dir: &Path, regex: &Regex, maildir_path: &Path) -> Option<String> {
                         break;
                     }
                     let subdir_path = subdir.path();
-                    let subdir_str = subdir_path.as_path().file_name().unwrap().to_str().unwrap();
+                    let subdir_str = path_filename_to_str!(subdir_path);
                     if subdir_str != "cur" &&
                         subdir_str != "new" &&
                         subdir_str != "tmp" {

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,10 +12,6 @@ use walkdir::WalkDir;
 
 use folder::Folder;
 
-lazy_static! {
-    pub static ref INBOX_RE : Regex = Regex::new("INBOX").unwrap();
-}
-
 #[macro_export]
 macro_rules! path_filename_to_str(
     ($p:ident) => (
@@ -45,10 +41,10 @@ pub fn perform_select(maildir: &str, select_args: &[&str], examine: bool,
                       tag: &str) -> (Option<Folder>, String) {
     let err_res = (None, "".to_string());
     if select_args.len() < 1 { return err_res; }
-    let mbox_name = INBOX_RE.replace(select_args[0].trim_matches('"'), ".");
+    let mbox_name = select_args[0].trim_matches('"').replace("INBOX", ".");
     let mut maildir_path = PathBuf::new();
     maildir_path.push(maildir);
-    maildir_path.push(mbox_name.as_ref());
+    maildir_path.push(mbox_name);
     let folder =  match Folder::new(maildir_path, examine) {
         None => { return err_res; }
         Some(folder) => folder.clone()
@@ -150,9 +146,7 @@ fn list_dir(dir: &Path, regex: &Regex, maildir_path: &Path) -> Option<String> {
             let mut list_str = "* LIST (".to_string();
             list_str.push_str(&flags[..]);
             list_str.push_str(") \"/\" ");
-            list_str.push_str(&(INBOX_RE.replace
-                              (&re.replace(&abs_dir[..], "INBOX")[..],
-                               ""))[..]);
+            list_str.push_str(&(re.replace(&abs_dir[..], "INBOX").replace("INBOX", ""))[..]);
             Some(list_str)
         }
     }


### PR DESCRIPTION
- Clean up all the unwraps, except for one around a Regex which looks rather hairy to avoid.
- Use `lazy_static` to more efficiently compile the regular expression.
- One pattern with converting a &Path filename to a &str involved two uses of `unwrap()`. I cleaned this up into a macro which is shared across modules.
- A `return_on_err` macro was duplicated in two modules. It has been deduplicated.
- A new Error type was created for one of the unwraps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uiri/segimap/24)
<!-- Reviewable:end -->
