### PR TITLE
Various minor fixes

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.133 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -77,6 +78,15 @@ dependencies = [
 name = "dtoa"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "env_logger"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "foreign-types"
@@ -477,6 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clippy 0.0.133 (registry+https://github.com/rust-lang/crates.io-index)" = "9022a83e66a654b0fa11143d9e37ad65b03ec4e317ac7198bd59d4d8714e6d5f"
 "checksum clippy_lints 0.0.133 (registry+https://github.com/rust-lang/crates.io-index)" = "95e0860d69a264f5533a01e5efe83386e320d93db636f60e59a8a47dd4865868"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clippy = { version = "0.0", optional = true }
 bufstream = "*"
+env_logger = "*"
 log = "*"
 nom = "*"
 num = "*"

--- a/core/src/folder.rs
+++ b/core/src/folder.rs
@@ -11,7 +11,7 @@ use message::Flag;
 use command::store::StoreName;
 
 /// Representation of a Folder
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Folder {
     // How many messages are in folder/new/
     recent: usize,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -6,6 +6,7 @@
 
 extern crate bufstream;
 extern crate crypto;
+extern crate env_logger;
 #[macro_use]
 extern crate log;
 extern crate mime;
@@ -73,6 +74,9 @@ fn listen_imap(v: TcpListener, serv: Arc<Server>) {
 }
 
 fn main() {
+    let _ = env_logger::init().unwrap();
+    info!("Application started");
+
     // Create the server. We wrap it so that it is atomically reference
     // counted. This allows us to safely share it across threads
 

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -77,7 +77,7 @@ impl Message {
         let mime_message = MIME_Message::new(arg_path)?;
 
         // Grab the string in the filename representing the flags
-        let mut path = path_filename_to_str!(arg_path).splitn(1, ':');
+        let mut path = path_filename_to_str!(arg_path).splitn(2, ':');
         let filename = match path.next() {
             Some(fname) => fname,
             None => { return Err(Error::MessageBadFilename); }
@@ -95,7 +95,7 @@ impl Message {
                 // The uid is separated from the flag part of the filename by a
                 // colon. The flag part consists of a 2 followed by a comma and
                 // then some letters. Those letters represent the message flags
-                match flags.splitn(1, ',').nth(1) {
+                match flags.splitn(2, ',').nth(1) {
                     None => HashSet::new(),
                     Some(unparsed_flags) => {
                         let mut set_flags: HashSet<Flag> = HashSet::new();
@@ -229,8 +229,8 @@ impl Message {
                         res.push_str(&self.mime_message.get_body(section, octets)[..]) },
                 /*
                 BodyStructure => {
-                    let content_type: Vec<&str> = (&self.headers["CONTENT-TYPE".to_string()][..]).splitn(1, ';').take(1).collect();
-                    let content_type: Vec<&str> = content_type[0].splitn(1, '/').collect();
+                    let content_type: Vec<&str> = (&self.headers["CONTENT-TYPE".to_string()][..]).splitn(2, ';').take(1).collect();
+                    let content_type: Vec<&str> = content_type[0].splitn(2, '/').collect();
 
                     // Retrieve the subtype of the content type.
                     let mut subtype = String::new();

--- a/core/src/user/session.rs
+++ b/core/src/user/session.rs
@@ -228,7 +228,7 @@ impl Session {
             "select" => {
                 let maildir = match self.maildir {
                     None => { return bad_res; }
-                    Some(ref maildir) => maildir.clone()
+                    Some(ref maildir) => maildir
                 };
                 let (folder, res) = util::perform_select(&maildir[..],
                                                          &args.collect::<Vec<&str>>(),
@@ -242,7 +242,7 @@ impl Session {
             "examine" => {
                 let maildir = match self.maildir {
                     None => { return bad_res; }
-                    Some(ref maildir) => maildir.clone()
+                    Some(ref maildir) => maildir
                 };
                 let (folder, res) = util::perform_select(&maildir[..],
                                                          &args.collect::<Vec<&str>>(),

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -39,7 +39,7 @@ pub fn perform_select(maildir: &str, select_args: &[&str], examine: bool,
     let mut maildir_path = PathBuf::new();
     maildir_path.push(maildir);
     maildir_path.push(mbox_name);
-    let folder =  match Folder::new(maildir_path, examine) {
+    let folder = match Folder::new(maildir_path, examine) {
         None => { return err_res; }
         Some(folder) => folder.clone()
     };

--- a/mime/src/lib.rs
+++ b/mime/src/lib.rs
@@ -91,14 +91,14 @@ impl Message {
                                            .trim_left_matches('\t'));
                     if !next.starts_with(' ') && !next.starts_with('\t') {
                         let split: Vec<&str> = (&trimmed_next[..])
-                                                .splitn(1, ':').collect();
+                                                .splitn(2, ':').collect();
                         headers.insert(split[0].to_ascii_uppercase(),
                                        split[1][1 .. ].to_string());
                         break;
                     }
                 }
             } else {
-                let split: Vec<&str> = line.splitn(1, ':').collect();
+                let split: Vec<&str> = line.splitn(2, ':').collect();
                 headers.insert(split[0].to_ascii_uppercase(),
                                split[1][1 .. ].to_string());
             }
@@ -123,7 +123,7 @@ impl Message {
                         if value.len() < 2 {
                             return Err(Error::ParseMultipartBoundary)
                         }
-                        let value: Vec<&str> = value[1].splitn(1, '"')
+                        let value: Vec<&str> = value[1].splitn(2, '"')
                                                 .collect();
                         if value.len() < 1 {
                             return Err(Error::ParseMultipartBoundary)
@@ -153,11 +153,11 @@ impl Message {
                         let header = &part[ .. header_boundary];
                         let mut content_type = String::new();
                         for line in header.lines() {
-                            let split_line: Vec<&str> = line.splitn(1, ':')
+                            let split_line: Vec<&str> = line.splitn(2, ':')
                                                          .collect();
                             if split_line[0] == "Content-Type" {
                                 let content_type_values: Vec<&str> =
-                                    split_line[1].splitn(1, ';').collect();
+                                    split_line[1].splitn(2, ';').collect();
                                 content_type = content_type_values[0][1 .. ].to_string();
                                 break;
                             }


### PR DESCRIPTION
Fixes a small typo, enables `env_logger` to allow for logging output, removes some unnecessary `clone()` calls, adds `Debug` to `Folder` (I needed this while debugging `Folder`, and everything should derive `Debug` anyways).

The biggest thing this PR addresses is the fact that the behaviour of `splitn` changed with RFC 979.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uiri/segimap/32)
<!-- Reviewable:end -->
